### PR TITLE
Add Slack LLM agent integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.10-slim
 
 WORKDIR /app
-COPY . /app
 
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
 
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ kanjiro/
 │       ├── base_agent.py
 │       ├── hanashi_kikoka.py
 │       ├── kennsaku_kennsaku.py
+│       ├── llm_agent.py
 │       ├── read_air.py
 │       └── shikiri_tagari.py
 ├── main.py
@@ -35,10 +36,10 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-3.  に環境変数を設定：
+3. `.env` に環境変数を設定：
 
-- SLACK_BOT_TOKEN
-- SLACK_SIGNING_SECRET
+- SLACK_BOT_TOKEN (ボットトークン)
+- SLACK_APP_TOKEN (Socket Mode用)
 - OPENAI_API_KEY
 
 4. 起動：
@@ -50,14 +51,14 @@ python main.py
 
 | エージェント名 | ファイル | 機能 |
 |----------------|----------|------|
-| ShikiriTagariAgent |  | 日程調整・仕切り役 |
-| ReadAirAgent        |         | 空気読み |
-| HanashiKikokaAgent  |   | 話の要点整理 |
-| KennsakuKennsakuAgent |  | お店検索（仮） |
+| ShikiriTagariAgent | shikiri_tagari.py | 日程調整・仕切り役 |
+| ReadAirAgent        | read_air.py | 空気読み |
+| HanashiKikokaAgent  | hanashi_kikoka.py | 話の要点整理 |
+| KennsakuKennsakuAgent | kennsaku_kennsaku.py | お店検索（仮） |
+| LLMAgent | llm_agent.py | OpenAI LLMによる応答 |
 
 ## 🔜 今後の予定
 
-- [ ] OpenAI API 統合による自然言語応答
 - [ ] Slackメッセージの分類 → 担当エージェント自動割当
 - [ ] Webhook対応（FastAPI導入）
 - [ ] Dockerコンテナ実行対応

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,0 +1,2 @@
+from .llm_agent import LLMAgent
+

--- a/app/agent/llm_agent.py
+++ b/app/agent/llm_agent.py
@@ -1,0 +1,26 @@
+import os
+from openai import OpenAI
+
+from .base_agent import BaseAgent
+
+
+class LLMAgent(BaseAgent):
+    """Agent that generates responses using an OpenAI model."""
+
+    def __init__(self, name: str = "LLMAgent") -> None:
+        super().__init__(name)
+        api_key = os.environ.get("OPENAI_API_KEY")
+        self.client = OpenAI(api_key=api_key) if api_key else OpenAI()
+
+    def respond(self, message: str) -> str:
+        completion = self.client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant responding in Japanese.",
+                },
+                {"role": "user", "content": message},
+            ],
+        )
+        return completion.choices[0].message["content"].strip()

--- a/main.py
+++ b/main.py
@@ -1,16 +1,29 @@
 import os
+
+from dotenv import load_dotenv
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
-from dotenv import load_dotenv
+
+from app.agent.llm_agent import LLMAgent
 
 load_dotenv()
+
 app = App(token=os.environ.get("SLACK_BOT_TOKEN"))
+llm_agent = LLMAgent()
+
 
 @app.event("app_mention")
 def handle_mention(event, say):
+    """Respond to mentions with an LLM-generated message."""
     user = event["user"]
-    say(f"<@{user}> 幹事郎が参上しました！ご用件はなんでしょうか？")
+    # Remove the mention from the incoming text
+    text = event.get("text", "")
+    prompt = text.split("<@", 1)[-1]
+    prompt = prompt.split(">", 1)[-1].strip()
+    response = llm_agent.respond(prompt)
+    say(f"<@{user}> {response}")
+
 
 if __name__ == "__main__":
-    handler = SocketModeHandler(app, os.environ.get("SLACK_BOT_TOKEN"))
+    handler = SocketModeHandler(app, os.environ.get("SLACK_APP_TOKEN"))
     handler.start()


### PR DESCRIPTION
## Summary
- add LLMAgent powered by OpenAI
- respond to Slack mentions with LLM output
- document required environment variables and docker build steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68934f645544832eae4c796fdf3d5e6d