### PR TITLE
Add Slack LLM agent integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM python:3.10-slim
-
+# コンテナ内の作業ディレクトリを設定
 WORKDIR /app
-COPY . /app
 
+# Dockerレイヤーのキャッシュを活かすため先にPython依存をインストール
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# 残りのアプリケーションコードをコピー
+COPY . ./
+
+# コンテナ起動時にSlackボットを実行
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ kanjiro/
 │       ├── base_agent.py
 │       ├── hanashi_kikoka.py
 │       ├── kennsaku_kennsaku.py
+│       ├── llm_agent.py
 │       ├── read_air.py
 │       └── shikiri_tagari.py
 ├── main.py
@@ -35,29 +36,35 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-3.  に環境変数を設定：
+3. `.env` に環境変数を設定：
 
-- SLACK_BOT_TOKEN
-- SLACK_SIGNING_SECRET
+- SLACK_BOT_TOKEN (ボットトークン)
+- SLACK_APP_TOKEN (Socket Mode用)
 - OPENAI_API_KEY
+- OPENAI_MODEL (任意: 使用するモデル名。未指定の場合は`gpt-3.5-turbo`)
 
 4. 起動：
 ```bash
 python main.py
 ```
 
+## 💬 Slackでの動作
+
+- チャンネルでボットをメンションすると **ShikiriTagariAgent** が応答します。
+- ボットとのDMでは **HanashiKikokaAgent** が個別にヒアリングします。
+
 ## 🤖 実装済みエージェント一覧
 
 | エージェント名 | ファイル | 機能 |
 |----------------|----------|------|
-| ShikiriTagariAgent |  | 日程調整・仕切り役 |
-| ReadAirAgent        |         | 空気読み |
-| HanashiKikokaAgent  |   | 話の要点整理 |
-| KennsakuKennsakuAgent |  | お店検索（仮） |
+| ShikiriTagariAgent | shikiri_tagari.py | 日程調整・仕切り役 |
+| ReadAirAgent        | read_air.py | 空気読み |
+| HanashiKikokaAgent  | hanashi_kikoka.py | 個人チャットで希望をヒアリング |
+| KennsakuKennsakuAgent | kennsaku_kennsaku.py | お店検索・予約候補提示 |
+| LLMAgent | llm_agent.py | ベースとなるLLMエージェント |
 
 ## 🔜 今後の予定
 
-- [ ] OpenAI API 統合による自然言語応答
 - [ ] Slackメッセージの分類 → 担当エージェント自動割当
 - [ ] Webhook対応（FastAPI導入）
 - [ ] Dockerコンテナ実行対応

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,0 +1,21 @@
+"""エージェントクラスをまとめて公開し、簡単にインポートできるようにする。"""
+
+# 下位モジュールの構造を意識せずに
+# `from app.agent import SomeAgent` と書けるよう各クラスをここでインポートする。
+from .base_agent import BaseAgent
+from .hanashi_kikoka import HanashiKikokaAgent
+from .kennsaku_kennsaku import KennsakuKennsakuAgent
+from .llm_agent import LLMAgent
+from .read_air import ReadAirAgent
+from .shikiri_tagari import ShikiriTagariAgent
+
+# `from app.agent import *` で公開クラスを再エクスポートする。
+__all__ = [
+    "BaseAgent",
+    "LLMAgent",
+    "ShikiriTagariAgent",
+    "ReadAirAgent",
+    "HanashiKikokaAgent",
+    "KennsakuKennsakuAgent",
+]
+

--- a/app/agent/hanashi_kikoka.py
+++ b/app/agent/hanashi_kikoka.py
@@ -1,5 +1,18 @@
-from .base_agent import BaseAgent
+"""DMで参加者と個別に会話するエージェント。"""
 
-class HanashiKikokaAgent(BaseAgent):
-    def respond(self, message: str) -> str:
-        return "なるほど、つまりこういう話ですね。整理してみます。"
+from .llm_agent import LLMAgent
+
+
+class HanashiKikokaAgent(LLMAgent):
+    """個人チャットで各参加者へのフォローを行う。"""
+
+    def __init__(self) -> None:
+        # 各参加者とのDMで丁寧な聞き取りを行うプロンプトを設定
+        super().__init__(
+            name="HanashiKikokaAgent",
+            system_prompt=(
+                "あなたは『話し聞こか』エージェントです。参加者の個人チャットで"\
+                "希望や懸念を丁寧にヒアリングし、日本語で応答してください。"
+            ),
+        )
+

--- a/app/agent/kennsaku_kennsaku.py
+++ b/app/agent/kennsaku_kennsaku.py
@@ -1,5 +1,18 @@
-from .base_agent import BaseAgent
+"""飲食店の検索と予約準備を担当するエージェント。"""
 
-class KennsakuKennsakuAgent(BaseAgent):
-    def respond(self, message: str) -> str:
-        return "ちょっとお店を検索してみますね。お待ちください。"
+from .llm_agent import LLMAgent
+
+
+class KennsakuKennsakuAgent(LLMAgent):
+    """指示に基づき飲食店を検索する。"""
+
+    def __init__(self) -> None:
+        # 都内の飲食店を条件に合わせて検索し候補を提示するプロンプトを設定
+        super().__init__(
+            name="KennsakuKennsakuAgent",
+            system_prompt=(
+                "あなたは『検索検索』エージェントです。与えられた条件から都内の"\
+                "飲食店を検索し、候補を日本語で提示してください。"
+            ),
+        )
+

--- a/app/agent/llm_agent.py
+++ b/app/agent/llm_agent.py
@@ -1,0 +1,46 @@
+"""幹事郎プロジェクトで使用されるLLMベースのエージェント。"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from openai import OpenAI
+
+from .base_agent import BaseAgent
+
+
+class LLMAgent(BaseAgent):
+    """OpenAIのチャットモデルで応答を生成するエージェント。"""
+
+    def __init__(
+        self,
+        name: str = "LLMAgent",
+        system_prompt: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        super().__init__(name)
+        # OpenAIクライアントを設定。APIキーが指定されない場合は環境変数などから取得する。
+        api_key = os.environ.get("OPENAI_API_KEY")
+        self.client = OpenAI(api_key=api_key) if api_key else OpenAI()
+
+        # エージェントの振る舞いを定義するシステムプロンプト。
+        # 各サブクラスは役割に応じて独自のプロンプトを渡せる。
+        self.system_prompt = (
+            system_prompt or "あなたは日本語で応答する有能なアシスタントです。"
+        )
+
+        # 使用するモデルは環境変数で上書きでき、デフォルトはgpt-3.5-turbo
+        self.model = model or os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
+
+    def respond(self, message: str) -> str:
+        # 会話をOpenAIのChat Completions APIに送信し、最初の応答を返す。
+        completion = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": message},
+            ],
+        )
+        return completion.choices[0].message["content"].strip()
+

--- a/app/agent/read_air.py
+++ b/app/agent/read_air.py
@@ -1,5 +1,18 @@
-from .base_agent import BaseAgent
+"""会話の文脈を解析し、他のエージェントへ指示を出すエージェント。"""
 
-class ReadAirAgent(BaseAgent):
-    def respond(self, message: str) -> str:
-        return "その発言、場の空気的にはちょっと微妙かもしれませんね…"
+from .llm_agent import LLMAgent
+
+
+class ReadAirAgent(LLMAgent):
+    """全てのメッセージをこっそり読み、他のエージェントを指揮する。"""
+
+    def __init__(self) -> None:
+        # 会話を解析して他エージェントへ簡潔な指示を出すプロンプトを設定
+        super().__init__(
+            name="ReadAirAgent",
+            system_prompt=(
+                "あなたは『空気読み』エージェントです。会話全体を把握し、"\
+                "他のエージェントへの簡潔な指示を日本語で出してください。"
+            ),
+        )
+

--- a/app/agent/shikiri_tagari.py
+++ b/app/agent/shikiri_tagari.py
@@ -1,5 +1,18 @@
-from .base_agent import BaseAgent
+"""グループチャットを主導するエージェント。"""
 
-class ShikiriTagariAgent(BaseAgent):
-    def respond(self, message: str) -> str:
-        return "では、日程候補をいくつか挙げますね！"
+from .llm_agent import LLMAgent
+
+
+class ShikiriTagariAgent(LLMAgent):
+    """グループチャットを進行し最終提案を行う。"""
+
+    def __init__(self) -> None:
+        # 全体の計画を調整し最終的な場所と日時を提案するプロンプトを設定
+        super().__init__(
+            name="ShikiriTagariAgent",
+            system_prompt=(
+                "あなたは幹事AI『仕切りたがり』です。参加者の希望を整理し、"\
+                "都内での飲み会の場所・日時・お店を提案してください。"
+            ),
+        )
+

--- a/main.py
+++ b/main.py
@@ -1,16 +1,59 @@
+"""幹事郎の各エージェントをSlackイベントに接続するエントリーポイント。"""
+
 import os
+
+from dotenv import load_dotenv
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
-from dotenv import load_dotenv
 
+from app.agent import (
+    HanashiKikokaAgent,
+    KennsakuKennsakuAgent,
+    ReadAirAgent,
+    ShikiriTagariAgent,
+)
+
+# 開発時にローカルの .env ファイルから環境変数を読み込む
 load_dotenv()
+
+# ボットトークンを使ってSlack Boltアプリを初期化
 app = App(token=os.environ.get("SLACK_BOT_TOKEN"))
+
+# 各役割のエージェントを生成
+shikiri_agent = ShikiriTagariAgent()  # グループ会話をリード
+read_air_agent = ReadAirAgent()  # すべてを観察して指示
+hanashi_agent = HanashiKikokaAgent()  # 個別DMを担当
+kennsaku_agent = KennsakuKennsakuAgent()  # 店舗検索を担当
+
 
 @app.event("app_mention")
 def handle_mention(event, say):
+    """メンションされた際にLLMで生成したメッセージで応答する。"""
     user = event["user"]
-    say(f"<@{user}> 幹事郎が参上しました！ご用件はなんでしょうか？")
+    # 受信テキストからメンション部分を取り除き、プロンプトを整形
+    text = event.get("text", "")
+    prompt = text.split("<@", 1)[-1]
+    prompt = prompt.split(">", 1)[-1].strip()
+
+    # 観察役のエージェントに読ませた後、仕切り役に返信させる
+    read_air_agent.respond(prompt)
+    response = shikiri_agent.respond(prompt)
+    say(f"<@{user}> {response}")
+
+
+@app.event("message")
+def handle_dm(event, say):
+    """参加者とのダイレクトメッセージに対応する。"""
+    if event.get("channel_type") != "im":
+        return
+    text = event.get("text", "")
+    # 個別のメッセージも空気読みエージェントが観察して希望を把握
+    read_air_agent.respond(text)
+    response = hanashi_agent.respond(text)
+    say(response)
+
 
 if __name__ == "__main__":
-    handler = SocketModeHandler(app, os.environ.get("SLACK_BOT_TOKEN"))
+    # Socket ModeでSlackアプリを実行し、公開HTTPエンドポイントを不要にする
+    handler = SocketModeHandler(app, os.environ.get("SLACK_APP_TOKEN"))
     handler.start()


### PR DESCRIPTION
## Summary
- add LLMAgent powered by OpenAI
- respond to Slack mentions with LLM output
- document required environment variables and docker build steps
- clarify agent logic and Dockerfile steps with descriptive comments
- translate inline comments and docstrings to Japanese

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68934f645544832eae4c796fdf3d5e6d