### PR TITLE
Remove DM handling and refactor to single-channel agent

### DIFF
--- a/app/agent/llm_agent.py
+++ b/app/agent/llm_agent.py
@@ -39,7 +39,7 @@ class LLMAgent:
                 "GEMINI_API_KEY_MAIN and GEMINI_API_KEY_SUMMARY must be set"
             )
 
-        model_name = model or os.environ.get("GEMINI_MODEL", "gemini-1.5-pro")
+        model_name = model or os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
         self.main_llm = ChatGoogleGenerativeAI(
             model=model_name, google_api_key=main_key
         )

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
-"""Slack でメンションとDMにだけ応答する最小構成。
+"""Slack でメンションにだけ応答する最小構成。
 
-チャンネルごとに会話コンテキストを保持する。"""
+単一チャンネルの会話コンテキストを保持する。"""
 
 import os
 import sys
@@ -40,21 +40,9 @@ def _strip_mention(text: str) -> str:
 @app.event("app_mention")
 def on_mention(event, say):
     user = event.get("user")
-    channel = event.get("channel")
     prompt = _strip_mention(event.get("text", ""))
-    reply = llm.respond(prompt, channel)
+    reply = llm.respond(prompt)
     say(f"<@{user}> {reply}")
-
-
-@app.event("message")
-def on_dm(event, say):
-    # DM のみ応答
-    if event.get("channel_type") != "im":
-        return
-    channel = event.get("channel")
-    text = event.get("text", "")
-    reply = llm.respond(text, channel)
-    say(reply)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove direct message event handler to only respond to mentions
- Simplify conversation management to a single channel and drop channel parameter

## Testing
- `python -m py_compile main.py app/agent/llm_agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bce3db4c34832eb0eba461e8bc196c